### PR TITLE
Add pymssql to spark16 dependencies

### DIFF
--- a/spark16/requirements.txt
+++ b/spark16/requirements.txt
@@ -20,6 +20,7 @@ pandas==0.18.0
 paramiko==1.13.0
 Pillow==3.1.1
 pykafka==2.1.2
+pymssql==2.1.3
 pysftp==0.2.9
 python-dateutil==2.4.2
 python-gnupg==0.3.8


### PR DESCRIPTION
`pymssql` is required to write evaluation metrics to SQL Server from CP-Rex.