### PR TITLE
Updated bingads library to support API V12

### DIFF
--- a/spark16/requirements.txt
+++ b/spark16/requirements.txt
@@ -1,6 +1,6 @@
 argparse==1.2.1
 azure-storage==0.20.3
-bingads==10.4.1
+bingads==11.12.5
 boto==2.39.0
 cryptography==1.4
 Fabric==1.10.2


### PR DESCRIPTION
Updated the bingads library in requirements.txt from 10.4.1 to 11.12.5 (the latest) to support Bing Ads Api version 12.