### PR TITLE
Updated bingads to support API v12 and added enum34

### DIFF
--- a/spark16/requirements_dev.txt
+++ b/spark16/requirements_dev.txt
@@ -1,7 +1,7 @@
 argparse==1.2.1
 azure-storage==0.20.3
 beautifulsoup4==4.6.0
-bingads==11.5.2
+bingads==11.12.5
 boto==2.39.0
 cryptography==1.4
 Fabric==1.10.2

--- a/spark16/requirements_dev.txt
+++ b/spark16/requirements_dev.txt
@@ -4,6 +4,7 @@ beautifulsoup4==4.6.0
 bingads==11.12.5
 boto==2.39.0
 cryptography==1.4
+enum34==1.1.6;python_version<"3.4"
 Fabric==1.10.2
 flake8==2.5.1
 googleads==10.0.0


### PR DESCRIPTION
Bing Ads Api version 11 is deprecated. In order to switch to version 12, we need to update the bingads library in the requirements. Also, since enum34 is a direct dependency of C-DataExtract, I have added it to the requirements.