### PR TITLE
Update vulnerable packages

### DIFF
--- a/spark16/requirements.txt
+++ b/spark16/requirements.txt
@@ -17,7 +17,7 @@ numpy==1.9.2
 oauth2==1.9.0.post1
 oauth2client==3.0.0
 pandas==0.18.0
-paramiko==2.0.2
+paramiko==2.4.1
 Pillow==3.1.1
 pykafka==2.1.2
 pymssql==2.1.3

--- a/spark16/requirements_dev.txt
+++ b/spark16/requirements_dev.txt
@@ -19,7 +19,7 @@ numpy==1.10.4
 oauth2==1.9.0.post1
 oauth2client==4.0.0
 pandas==0.18.0
-paramiko==2.0.2
+paramiko==2.4.1
 Pillow==5.1.0
 pycountry==1.20
 pykafka==2.7.0

--- a/spark16/requirements_prod.txt
+++ b/spark16/requirements_prod.txt
@@ -17,7 +17,7 @@ numpy==1.10.4
 oauth2==1.9.0.post1
 oauth2client==4.0.0
 pandas==0.18.0
-paramiko==2.0.2
+paramiko==2.4.1
 Pillow==3.1.1
 pycountry==1.20
 pykafka==2.1.2

--- a/spark16/requirements_qa.txt
+++ b/spark16/requirements_qa.txt
@@ -18,7 +18,7 @@ numpy==1.10.4
 oauth2==1.9.0.post1
 oauth2client==4.0.0
 pandas==0.18.0
-paramiko==2.0.2
+paramiko==2.4.1
 Pillow==3.1.1
 pycountry==1.20
 pykafka==2.7.0

--- a/spark16/requirements_temp.txt
+++ b/spark16/requirements_temp.txt
@@ -17,7 +17,7 @@ numpy==1.14.2
 oauth2==1.9.0.post1
 oauth2client==3.0.0
 pandas==0.21.0
-paramiko==2.0.2
+paramiko==2.4.1
 Pillow==3.1.1
 pycountry==1.20
 pykafka==2.1.2


### PR DESCRIPTION
The GitHub vulnerability report recommends updating the paramiko library due to security concerns. To solve this issue, I've updated all requirements files to the latest paramiko version.