### PR TITLE
Downgrade requests to 2.21.0

### DIFF
--- a/cmm/requirements.txt
+++ b/cmm/requirements.txt
@@ -14,7 +14,7 @@ pytest==3.0.7
 python-dateutil==2.7.2
 pytz==2018.4
 PyYAML==5.1.2
-requests==2.22.0
+requests==2.21.0
 s3transfer==0.1.13
 simplegeneric==0.8.1
 SQLAlchemy==1.3.6


### PR DESCRIPTION
2.22.0 dropped support for Py3.4