### PR TITLE
Update google api client library

### DIFF
--- a/seo/requirements.txt
+++ b/seo/requirements.txt
@@ -4,7 +4,7 @@ cryptography==3.3.2
 flake8==3.7.7
 freezegun==0.3.9
 googleads==17.0.0
-google-api-python-client==1.7.4
+google-api-python-client==2.26.0
 gspread==3.6.0
 invoke==1.2.0
 ipdb==0.8.1


### PR DESCRIPTION
Updating google-api-python-client library from 1.7.4 to 2.26.0 in order to resolve a breaking issue preventing the ability to create a service connection to the google search console api