### PR TITLE
Added PyNaCL==1.4.0 to keep supporting python 3.6. Remove paramiko as…

### DIFF
--- a/display/requirements.txt
+++ b/display/requirements.txt
@@ -14,6 +14,7 @@ numpy==1.16.4
 oauth2==1.9.0.post1
 oauth2client==4.0.0
 pandas==0.25.3
+paramiko==2.7.1
 pycountry==1.20
 pymssql==2.1.4
 pyOpenSSL==18.0.0

--- a/display/requirements.txt
+++ b/display/requirements.txt
@@ -14,11 +14,9 @@ numpy==1.16.4
 oauth2==1.9.0.post1
 oauth2client==4.0.0
 pandas==0.25.3
-paramiko==2.7.1
 pycountry==1.20
 pymssql==2.1.4
 pyOpenSSL==18.0.0
-pysftp==0.2.9
 pytest==4.3.1
 python-dateutil==2.5.0
 python-gnupg==0.4.5

--- a/display/requirements.txt
+++ b/display/requirements.txt
@@ -1,3 +1,4 @@
+PyNaCL==1.4.0
 beautifulsoup4==4.6.0
 boto3==1.10.37
 cryptography==3.3.2

--- a/search/requirements.txt
+++ b/search/requirements.txt
@@ -16,6 +16,7 @@ nose==1.3.7
 numpy==1.16.4
 oauth2==1.9.0.post1
 oauth2client==4.0.0
+paramiko==2.7.1
 pandas==0.25.3
 pycountry==1.20
 pymssql==2.1.4

--- a/search/requirements.txt
+++ b/search/requirements.txt
@@ -1,3 +1,4 @@
+PyNaCL==1.4.0
 beautifulsoup4==4.6.0
 bingads==13.0.5
 boto3==1.10.37
@@ -16,7 +17,6 @@ numpy==1.16.4
 oauth2==1.9.0.post1
 oauth2client==4.0.0
 pandas==0.25.3
-paramiko==2.7.1
 pycountry==1.20
 pymssql==2.1.4
 pyOpenSSL==18.0.0

--- a/seo/requirements.txt
+++ b/seo/requirements.txt
@@ -17,6 +17,7 @@ nose==1.3.7
 numpy==1.16.4
 oauth2==1.9.0.post1
 oauth2client==4.0.0
+paramiko==2.7.1
 pandas==0.25.3
 pycountry==1.20
 pymssql==2.1.4

--- a/seo/requirements.txt
+++ b/seo/requirements.txt
@@ -1,3 +1,4 @@
+PyNaCL==1.4.0
 beautifulsoup4==4.6.0
 boto3==1.10.37
 cryptography==3.3.2
@@ -17,7 +18,6 @@ numpy==1.16.4
 oauth2==1.9.0.post1
 oauth2client==4.0.0
 pandas==0.25.3
-paramiko==2.7.1
 pycountry==1.20
 pymssql==2.1.4
 pyOpenSSL==18.0.0


### PR DESCRIPTION
Paramiko it is no needed for the project but TC imports the task.py package which in turns imports the Paramiko lib. Even tho we used to use that piece of code to deploy to azkaban, we need to deprecate that code